### PR TITLE
Update hiwifi-hc5761.patch

### DIFF
--- a/hiwifi-hc5761.patch
+++ b/hiwifi-hc5761.patch
@@ -141,6 +141,7 @@ Index: target/linux/ramips/dts/HiWiFi-HC5761.dts
 +		mtd-mac-address = <&bdinfo 0x18a>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
++		mtd-mac-address = <&factory 0x4>;
 +
 +		ralink,port-map = "wllll";
 +


### PR DESCRIPTION
解决eth不能获得MAC地址而导致不能启用的问题，同时解决了不能使用动态DHCP分配IP地址的问题.(可直接使用不死Uboot刷机)
